### PR TITLE
Fix help output

### DIFF
--- a/src/click/_textwrap.py
+++ b/src/click/_textwrap.py
@@ -35,3 +35,6 @@ class TextWrapper(textwrap.TextWrapper):
                 indent = self.subsequent_indent
             rv.append(indent + line)
         return "\n".join(rv)
+
+    def fill(self, text):
+        return " ".join(self.wrap(text))

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -975,7 +975,7 @@ class Command(BaseCommand):
         self.format_help(ctx, formatter)
         return formatter.getvalue().rstrip("\n")
 
-    def get_short_help_str(self, limit=45):
+    def get_short_help_str(self, limit=110):
         """Gets short help for the command or makes it by shortening the
         long help string.
         """
@@ -1191,13 +1191,9 @@ class MultiCommand(Command):
 
             commands.append((subcommand, cmd))
 
-        # allow for 3 times the default spacing
-        if len(commands):
-            limit = formatter.width - 6 - max(len(cmd[0]) for cmd in commands)
-
             rows = []
             for subcommand, cmd in commands:
-                help = cmd.get_short_help_str(limit)
+                help = cmd.get_short_help_str()
                 rows.append((subcommand, help))
 
             if rows:

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1191,6 +1191,8 @@ class MultiCommand(Command):
 
             commands.append((subcommand, cmd))
 
+        # allow for 3 times the default spacing
+        if len(commands):
             rows = []
             for subcommand, cmd in commands:
                 help = cmd.get_short_help_str()

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -187,7 +187,7 @@ class HelpFormatter(object):
         )
         self.write("\n")
 
-    def write_dl(self, rows, col_max=30, col_spacing=2):
+    def write_dl(self, rows, col_max=50, col_spacing=2):
         """Writes a definition list into the buffer.  This is how options
         and commands are usually formatted.
 
@@ -214,7 +214,7 @@ class HelpFormatter(object):
                 self.write("\n")
                 self.write(" " * (first_col + self.current_indent))
 
-            text_width = max(self.width - first_col - 2, 10)
+            text_width = max(self.width - first_col - 2, 110)
             wrapped_text = wrap_text(second, text_width, preserve_paragraphs=True)
             lines = wrapped_text.splitlines()
 

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -55,7 +55,7 @@ def make_str(value):
     return text_type(value)
 
 
-def make_default_short_help(help, max_length=45):
+def make_default_short_help(help, max_length=110):
     """Return a condensed version of help string."""
     words = help.split()
     total_length = 0


### PR DESCRIPTION
Example for display resolution 1280x720
![image](https://user-images.githubusercontent.com/60649733/115052150-460f3300-9ee6-11eb-8d87-ef32ff518161.png)
Example for display resolution 1920x1080
![image](https://user-images.githubusercontent.com/60649733/115053538-e9ad1300-9ee7-11eb-887b-9480de2f2303.png)

Also the "azure" group has the longest command name, and as you can see in the screenshots, the names do not shift the description.
At the moment, only three commands do not display a full description:
- m3admin azure tenant
- m3admin azure register_common_credentials
- m3admin environment add_position_to_tenant